### PR TITLE
✨feat: show the sample size field in the table of the analysis result

### DIFF
--- a/ui/src/interfaces/analysis.ts
+++ b/ui/src/interfaces/analysis.ts
@@ -33,6 +33,7 @@ interface IAnalysisData {
     upper: number;
   };
   distributionChart: IDistribution[];
+  sampleSize: number;
 }
 
 export interface IChartData {
@@ -48,4 +49,5 @@ export interface ITableData {
     upper: number;
   };
   mean?: number;
+  sampleSize?: number;
 }

--- a/ui/src/locales/en-US.json
+++ b/ui/src/locales/en-US.json
@@ -630,5 +630,6 @@
   "analysis.result.table.name": "Variation",
   "analysis.result.table.percentage": "Probability to be the best",
   "analysis.result.table.credibleInterval": "Credible inteval: 90%",
-  "analysis.result.table.mean": "Posterior mean"
+  "analysis.result.table.mean": "Posterior mean",
+  "analysis.result.table.samplesize": "Sample size"
 }

--- a/ui/src/locales/zh-CN.json
+++ b/ui/src/locales/zh-CN.json
@@ -630,5 +630,6 @@
   "analysis.result.table.name": "分组名称",
   "analysis.result.table.percentage": "胜出概率",
   "analysis.result.table.credibleInterval": "90%可信区间",
-  "analysis.result.table.mean": "后验均值"
+  "analysis.result.table.mean": "后验均值",
+  "analysis.result.table.samplesize": "样本总量"
 }

--- a/ui/src/pages/analysis/components/Results/components/table/index.tsx
+++ b/ui/src/pages/analysis/components/Results/components/table/index.tsx
@@ -23,6 +23,9 @@ const ResultTable = (props: IProps) => {
             <Table.HeaderCell className={styles['column-probability']}>
               <FormattedMessage id='analysis.result.table.percentage' />
             </Table.HeaderCell>
+            <Table.HeaderCell className={styles['column-probability']}>
+              <FormattedMessage id='analysis.result.table.samplesize' />
+            </Table.HeaderCell>
             <Table.HeaderCell>
               <FormattedMessage id='analysis.result.table.credibleInterval' />
             </Table.HeaderCell>
@@ -45,6 +48,11 @@ const ResultTable = (props: IProps) => {
                   <Table.Cell className={styles.probability}>
                     <div className={styles['probability-text']}>
                       {(Number(item.winningPercentage) * 100).toFixed(2) + '%'}
+                    </div>
+                  </Table.Cell>
+                  <Table.Cell>
+                    <div>
+                      {item.sampleSize}
                     </div>
                   </Table.Cell>
                   <Table.Cell>

--- a/ui/src/pages/analysis/components/Results/index.tsx
+++ b/ui/src/pages/analysis/components/Results/index.tsx
@@ -81,6 +81,7 @@ const Results = (props: IProps) => {
         mean: result[item].mean,
         winningPercentage: result[item].winningPercentage,
         credibleInterval: result[item].credibleInterval,
+        sampleSize: result[item].sampleSize
       });
 
       labels = result[item].distributionChart.map((val: IDistribution) => {


### PR DESCRIPTION
Fix #170 

Changes proposed in this pull request:

* Show the sample size field in the table of the analysis result


