### PR TITLE
:book: docs: add track event docs to the Go SDK

### DIFF
--- a/docs/docs/how-to/Server-Side SDKs/golang-sdk.md
+++ b/docs/docs/how-to/Server-Side SDKs/golang-sdk.md
@@ -89,6 +89,24 @@ fpClient.Close();
 ```
 
 
+## Track Events
+
+:::note
+The Go SDK supports event tracking from version 2.0.1.
+:::
+
+The event tracking feature can record the actions taken by the user in the application as events.
+
+Events are related to toggle's metrics. For more information about event analysis, please read [Event Analysis](../../tutorials/analysis).
+
+```go
+value := 99.9
+fpClient.track("YOUR_CUSTOM_EVENT_NAME", user, nil)
+// Providing a metric value to track
+fpClient.track("YOUR_CUSTOM_EVENT_NAME", user, &value)
+```
+
+
 ## Unit Testing
 
 FeatureProbe SDK provides a set of mock mechanism, which can specify the return value of FeatureProbe SDK in unit test.

--- a/docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/how-to/Server-Side SDKs/golang-sdk.md
+++ b/docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/how-to/Server-Side SDKs/golang-sdk.md
@@ -85,6 +85,22 @@ if toggle {
 fpClient.Close();
 ```
 
+## 事件上报
+
+:::note
+Go SDK 从 2.0.1 版本开始支持事件上报的能力
+:::
+
+事件跟踪功能可以将用户在应用程序中采取的操作记录为事件。
+可以在开关的指标中关联事件。更多指标分析相关的信息，请阅读[指标分析](../../tutorials/analysis)。
+
+```go
+value := 99.9
+fpClient.track("YOUR_CUSTOM_EVENT_NAME", user, nil)
+// Providing a metric value to track
+fpClient.track("YOUR_CUSTOM_EVENT_NAME", user, &value)
+```
+
 ## 接入业务单元测试
 
 FeatureProbe SDK 提供了一套mock机制，可以在单元测试中指定FeatureProbe SDK的返回值。

--- a/ui/src/pages/connectSDK/components/TestConnection/index.tsx
+++ b/ui/src/pages/connectSDK/components/TestConnection/index.tsx
@@ -49,6 +49,7 @@ const TestConnection = (props: IProps) => {
   const [ displayName, saveDisplayName ] = useState<string>('');
   const intl = useIntl();
   const faqUrl = useRef('');
+  const metricFaqUrl = useRef('');
 
   const stepTitleCls = classNames(
     styles['step-title'],
@@ -98,8 +99,10 @@ const TestConnection = (props: IProps) => {
   useEffect(() => {
     if (intl.locale === 'zh-CN') {
       faqUrl.current = 'https://docs.featureprobe.io/zh-CN/introduction/faq/#14-%E6%8E%A5%E5%85%A5%E5%BC%95%E5%AF%BC%E6%8F%90%E7%A4%BA-%E6%82%A8%E6%B2%A1%E6%9C%89%E6%AD%A4-sdk-%E5%AF%86%E9%92%A5%E8%BF%9E%E6%8E%A5%E6%88%90%E5%8A%9F%E7%9A%84%E5%BA%94%E7%94%A8%E7%A8%8B%E5%BA%8F-%E8%AF%A5%E5%A6%82%E4%BD%95%E6%8E%92%E6%9F%A5';
+      metricFaqUrl.current = 'https://docs.featureprobe.io/zh-CN/introduction/faq#15-%E6%8E%A5%E5%85%A5%E5%BC%95%E5%AF%BC%E6%8F%90%E7%A4%BA-%E6%82%A8%E6%B2%A1%E6%9C%89%E5%BA%94%E7%94%A8%E7%A8%8B%E5%BA%8F%E6%AD%A3%E5%9C%A8-x-%E7%8E%AF%E5%A2%83%E4%B8%AD%E7%9B%91%E5%90%AC-x-%E5%BC%80%E5%85%B3%E7%9A%84-x-%E4%BA%8B%E4%BB%B6-%E8%AF%A5%E5%A6%82%E4%BD%95%E6%8E%92%E6%9F%A5';
     } else if(intl.locale === 'en-US') {
       faqUrl.current = 'https://docs.featureprobe.io/introduction/faq/#14-how-to-solve-you-have-no-applications-connected-using-this-sdk-key-in-user-guidance-of-sdk-initialization';
+      metricFaqUrl.current = 'https://docs.featureprobe.io/introduction/faq/#15-how-to-solve-you-dont-have-any-application-listening-for-the-x-event-on-x-toggle-in-x-environment';
     }
   }, [intl]);
 
@@ -221,14 +224,14 @@ const TestConnection = (props: IProps) => {
                                 toggle: toggleKey,
                               })
                             }
-                            {/* <a 
+                            {<a 
                               className={styles['error-link']}
                               target='_blank'
                               rel='noreferrer'
-                              href={faqUrl.current}
+                              href={metricFaqUrl.current}
                             >
                               <FormattedMessage id='connect.fourth.failed.link' />
-                            </a> */}
+                            </a> }
                           </div>
                           <div className={styles['retry-connection']}>
                             <Button 

--- a/ui/src/pages/connectSDK/components/TrackEvent/index.tsx
+++ b/ui/src/pages/connectSDK/components/TrackEvent/index.tsx
@@ -9,12 +9,13 @@ import CopyToClipboardPopup from 'components/CopyToClipboard';
 import {
   SdkLanguage,
   getJavaTrackCode,
+  getGoTrackCode,
   getRustTrackCode,
   getAndroidTrackCode,
   getSwiftTrackCode,
   getObjCTrackCode,
   getJSTrackCode,
-  getReactTrackCode
+  getReactTrackCode,
 } from '../../constants';
 
 import styles from '../../index.module.scss';
@@ -63,6 +64,15 @@ const SetupCode = (props: IProps) => {
           saveLanguage('java');
           saveOptions(
             getJavaTrackCode({
+              intl, 
+              eventName,
+            })
+          );
+          break;
+        case 'Go':
+          saveLanguage('go');
+          saveOptions(
+            getGoTrackCode({
               intl, 
               eventName,
             })

--- a/ui/src/pages/connectSDK/constants.ts
+++ b/ui/src/pages/connectSDK/constants.ts
@@ -99,6 +99,7 @@ export const SDK_VERSION = new Map([
 
 export const AVAILABLE_SDKS = [
   'Java',
+  'Go',
   'Rust',
   'Android',
   'Swift',
@@ -275,6 +276,21 @@ ${returnType === 'boolean' ? `val := fp.BoolValue("${toggleKey}", user, true)` :
           `fp.Close();
 `
     }
+  ];
+};
+
+export const getGoTrackCode = (options: ITrackOption) => {
+  const { intl, eventName } = options;
+  return [
+    {
+      title: intl.formatMessage({id: intl.formatMessage({id: 'getstarted.track.event.title'})}),
+      code:
+`value := 5.5
+fp.track("${eventName}", user, nil)
+// Providing a metric value to track
+fp.track("${eventName}", user, &value)
+`
+    },
   ];
 };
 


### PR DESCRIPTION
Fix: #104

Changes proposed in this pull request:

* add track event docs to the Go SDK
*
*


